### PR TITLE
fix kumascript unit-test errors

### DIFF
--- a/kumascript/macros/APIRef.ejs
+++ b/kumascript/macros/APIRef.ejs
@@ -94,9 +94,6 @@ if (impl.length > 0) {
 }
 
 function APISort(a, b) {
-  if (!a.title || !b.title) {
-  console.log({a: a, b:b})
-  }
   var aSplit = a.title.split('.');
   var a = aSplit[aSplit.length - 1];
   var bSplit = b.title.split('.');

--- a/kumascript/src/errors.js
+++ b/kumascript/src/errors.js
@@ -16,7 +16,6 @@ class SourceCodeError {
     // instances of this class. Otherwise we'd need to monkey-patch
     // the `.toJSON` of `Error` which feels fragile.
     this.errorStack = error.stack;
-
     this.offset = 0;
     this.line = line;
     this.column = column;
@@ -29,7 +28,7 @@ class SourceCodeError {
     // Generates a unique key for this error.
     return [
       this.name,
-      this.errorStack,
+      this.error.message,
       this.line,
       this.column,
       this.filepath,

--- a/kumascript/tests/index.test.js
+++ b/kumascript/tests/index.test.js
@@ -43,7 +43,6 @@ describe("testing the main render() function", () => {
           metadata: {
             title: "A",
             locale: "en-US",
-            summary: "This is the A test page.",
             slug: "Web/A",
             tags: ["Web"],
           },
@@ -58,7 +57,6 @@ describe("testing the main render() function", () => {
           metadata: {
             title: "B",
             locale: "en-US",
-            summary: "This is the B test page.",
             slug: "Web/B",
             tags: ["Web"],
           },
@@ -73,7 +71,6 @@ describe("testing the main render() function", () => {
           metadata: {
             title: "C",
             locale: "en-US",
-            summary: "This is the C test page.",
             slug: "Web/C",
             tags: ["Web"],
           },
@@ -88,7 +85,6 @@ describe("testing the main render() function", () => {
           metadata: {
             title: "<number>",
             locale: "en-US",
-            summary: "This is the number test page.",
             slug: "Web/Number",
             tags: ["Web", "CSS", "CSS Data Type", "Layout", "Reference"],
           },
@@ -143,8 +139,8 @@ describe("testing the main render() function", () => {
       "testing/content/files/en-us/web/b"
     );
     expect(errors[0]).toHaveProperty(
-      "errorMessage",
-      "/en-US/docs/Web/CSS/bigfoot does not exist"
+      "errorStack",
+      expect.stringContaining("/en-US/docs/Web/CSS/bigfoot does not exist")
     );
     expect(errors[0]).toHaveProperty("macroName", "cssxref");
     expect(errors[0]).toHaveProperty("macroSource", '{{cssxref("bigfoot")}}');
@@ -156,8 +152,8 @@ describe("testing the main render() function", () => {
       "testing/content/files/en-us/web/a"
     );
     expect(errors[1]).toHaveProperty(
-      "errorMessage",
-      "/en-US/docs/Web/CSS/bigfoot does not exist"
+      "errorStack",
+      expect.stringContaining("/en-US/docs/Web/CSS/bigfoot does not exist")
     );
     expect(errors[1]).toHaveProperty("macroName", "cssxref");
     expect(errors[1]).toHaveProperty("macroSource", '{{cssxref("bigfoot")}}');
@@ -170,8 +166,8 @@ describe("testing the main render() function", () => {
     );
     expect(errors[2]).toHaveProperty("macroName", "nonExistentMacro");
     expect(errors[2]).toHaveProperty(
-      "errorMessage",
-      "Unknown macro nonexistentmacro"
+      "errorStack",
+      expect.stringContaining("Unknown macro nonexistentmacro")
     );
     expect(errors[3]).toBeInstanceOf(MacroRedirectedLinkError);
     expect(errors[3]).toHaveProperty("line", 10);
@@ -181,8 +177,10 @@ describe("testing the main render() function", () => {
       "testing/content/files/en-us/web/a"
     );
     expect(errors[3]).toHaveProperty(
-      "errorMessage",
-      "/en-US/docs/Web/CSS/dumber redirects to /en-US/docs/Web/CSS/number"
+      "errorStack",
+      expect.stringContaining(
+        "/en-US/docs/Web/CSS/dumber redirects to /en-US/docs/Web/CSS/number"
+      )
     );
     expect(errors[3]).toHaveProperty("macroName", "cssxref");
     expect(errors[3]).toHaveProperty("macroSource", '{{cssxref("dumber")}}');
@@ -197,8 +195,10 @@ describe("testing the main render() function", () => {
     );
     expect(errors[4]).toHaveProperty("macroName", "fx_minversion_header");
     expect(errors[4]).toHaveProperty(
-      "errorMessage",
-      "This macro has been deprecated, and should be removed."
+      "errorStack",
+      expect.stringContaining(
+        "This macro has been deprecated, and should be removed."
+      )
     );
     expect(errors[5]).toBeInstanceOf(MacroDeprecatedError);
     expect(errors[5]).toHaveProperty("line", 13);
@@ -209,8 +209,10 @@ describe("testing the main render() function", () => {
     );
     expect(errors[5]).toHaveProperty("macroName", "fx_minversion_inline");
     expect(errors[5]).toHaveProperty(
-      "errorMessage",
-      "This macro has been deprecated, and should be removed."
+      "errorStack",
+      expect.stringContaining(
+        "This macro has been deprecated, and should be removed."
+      )
     );
     expect(errors[6]).toBeInstanceOf(MacroDeprecatedError);
     expect(errors[6]).toHaveProperty("line", 14);
@@ -221,8 +223,10 @@ describe("testing the main render() function", () => {
     );
     expect(errors[6]).toHaveProperty("macroName", "gecko_minversion_header");
     expect(errors[6]).toHaveProperty(
-      "errorMessage",
-      "This macro has been deprecated, and should be removed."
+      "errorStack",
+      expect.stringContaining(
+        "This macro has been deprecated, and should be removed."
+      )
     );
     expect(errors[7]).toBeInstanceOf(MacroDeprecatedError);
     expect(errors[7]).toHaveProperty("line", 15);
@@ -233,8 +237,10 @@ describe("testing the main render() function", () => {
     );
     expect(errors[7]).toHaveProperty("macroName", "gecko_minversion_inline");
     expect(errors[7]).toHaveProperty(
-      "errorMessage",
-      "This macro has been deprecated, and should be removed."
+      "errorStack",
+      expect.stringContaining(
+        "This macro has been deprecated, and should be removed."
+      )
     );
     expect(errors[8]).toBeInstanceOf(MacroExecutionError);
     expect(errors[8]).toHaveProperty("line", 16);
@@ -245,7 +251,7 @@ describe("testing the main render() function", () => {
     );
     expect(errors[8]).toHaveProperty("macroName", "page");
     expect(errors[8]).toHaveProperty(
-      "errorMessage",
+      "errorStack",
       expect.stringContaining(
         "/en-us/docs/web/a references bogus, which does not exist"
       )
@@ -259,7 +265,7 @@ describe("testing the main render() function", () => {
     );
     expect(errors[9]).toHaveProperty("macroName", "page");
     expect(errors[9]).toHaveProperty(
-      "errorMessage",
+      "errorStack",
       expect.stringContaining(
         'unable to find an HTML element with an "id" of "bogus-section" within /en-us/docs/web/b'
       )

--- a/kumascript/tests/macros/page-api.test.js
+++ b/kumascript/tests/macros/page-api.test.js
@@ -172,7 +172,7 @@ describeMacro("page API tests", function () {
     itMacro("One argument (throws error)", function (macro) {
       const junk_url = "/en-US/docs/junk";
       expect(() => macro.ctx.page.translations(junk_url)).toThrow(
-        `${junk_url.toLowerCase()} does not exist`
+        `${junk_url.toLowerCase()} (url: ${junk_url}) does not exist`
       );
     });
   });


### PR DESCRIPTION
@peterbe I had to change the way the error `key` is generated because using `errorStack` would defeat the de-duplication of errors (since the same errors were generated via different code paths), but everything else was routine.