### PR TITLE
refactor: small sass refactor for index and sidebar icons

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -170,6 +170,15 @@ a.new {
   */
   .index {
     columns: 300px;
+
+    .icon-experimental,
+    .icon-nonstandard {
+      color: $primary-50;
+    }
+
+    .icon-deprecated {
+      color: $red-100;
+    }
   }
 
   iframe {
@@ -178,20 +187,6 @@ a.new {
 
   iframe:not(.sample-code-frame) {
     border: 0;
-  }
-
-  /*
-   * Used in sidebars and in indexes which are both lists of links.
-   */
-  .sidebar .icon-experimental,
-  .index .icon-experimental,
-  .sidebar .icon-nonstandard,
-  .index .icon-nonstandard {
-    color: $primary-50;
-  }
-  .sidebar .icon-deprecated,
-  .index .icon-deprecated {
-    color: $red-100;
   }
 }
 

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -53,4 +53,14 @@
     height: 18px;
     width: 18px;
   }
+
+  /* icons in sidebars */
+  .icon-experimental,
+  .icon-nonstandard {
+    color: $primary-50;
+  }
+
+  .icon-deprecated {
+    color: $red-100;
+  }
 }


### PR DESCRIPTION
Refactors where we define the colors for icons used in sidebars and icons in containers with a class of `index`.
We might want to think about creating a single SASS file for icons but, perhaps it is good to have the sidebar icons closely colocated with the sidebar etc.